### PR TITLE
fix: Use static value for revalidate segment config

### DIFF
--- a/app/api/homepage/content/route.ts
+++ b/app/api/homepage/content/route.ts
@@ -27,7 +27,8 @@ import { unstable_cache } from 'next/cache';
 export const runtime = 'edge';
 
 // ISR revalidation configuration
-export const revalidate = CACHE_TTL.HOMEPAGE_CONTENT;
+// Note: Must be a static value, not an expression (Next.js requirement)
+export const revalidate = 3600; // 1 hour (matches CACHE_TTL.HOMEPAGE_CONTENT)
 
 // ============================================================================
 // TYPES


### PR DESCRIPTION
## Summary
- Fixed CI build failure caused by using dynamic expression for `revalidate` segment config
- Changed `CACHE_TTL.HOMEPAGE_CONTENT` to static value `3600` (1 hour)
- Next.js requires segment config exports to be static values, not expressions

## Problem
The build was failing with:
```
Unsupported node type "MemberExpression" at "revalidate"
```

This occurs during Next.js static analysis of route segment configs, which cannot evaluate runtime expressions.

## Test plan
- [ ] Verify CI build passes
- [ ] Verify homepage content API still works correctly with 1-hour cache TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)